### PR TITLE
added communication to ms service to stop miner service

### DIFF
--- a/app/resources/wallet.py
+++ b/app/resources/wallet.py
@@ -81,6 +81,8 @@ def reset(data: dict, user: str) -> dict:
     if wallet.user_uuid != user:
         return permission_denied
 
+    m.contact_microservice("service", ["toggle_miner"], {"wallet_uuid": wallet.source_uuid})
+
     wrapper.session.delete(wallet)
     wrapper.session.commit()
 
@@ -94,6 +96,8 @@ def delete(data: dict, user: str) -> dict:
     wallet: Wallet = wrapper.session.query(Wallet).filter_by(source_uuid=source_uuid, key=key).first()
     if wallet is None:
         return unknown_source_or_destination
+
+    m.contact_microservice("service", ["toggle_miner"], {"wallet_uuid": wallet.source_uuid})
 
     wrapper.session.delete(wallet)
     wrapper.session.commit()

--- a/app/resources/wallet.py
+++ b/app/resources/wallet.py
@@ -81,7 +81,7 @@ def reset(data: dict, user: str) -> dict:
     if wallet.user_uuid != user:
         return permission_denied
 
-    m.contact_microservice("service", ["toggle_miner"], {"wallet_uuid": wallet.source_uuid})
+    m.contact_microservice("service", ["miner", "stop"], {"wallet_uuid": wallet.source_uuid})
 
     wrapper.session.delete(wallet)
     wrapper.session.commit()
@@ -97,7 +97,7 @@ def delete(data: dict, user: str) -> dict:
     if wallet is None:
         return unknown_source_or_destination
 
-    m.contact_microservice("service", ["toggle_miner"], {"wallet_uuid": wallet.source_uuid})
+    m.contact_microservice("service", ["miner", "stop"], {"wallet_uuid": wallet.source_uuid})
 
     wrapper.session.delete(wallet)
     wrapper.session.commit()

--- a/app/tests/test_wallet.py
+++ b/app/tests/test_wallet.py
@@ -253,6 +253,7 @@ class TestWallet(TestCase):
     def test__user_endpoint__reset__successful(self):
         test_wallet = mock.MagicMock()
         test_wallet.user_uuid = "the-user"
+        test_wallet.source_uuid = "the-source"
 
         self.query_wallet.filter_by().first.return_value = test_wallet
 
@@ -262,6 +263,7 @@ class TestWallet(TestCase):
         self.assertEqual(expected_result, actual_result)
         self.query_wallet.filter_by.assert_called_with(source_uuid="the-source")
         self.query_wallet.filter_by().first.assert_called_with()
+        mock.m.contact_microservice.assert_called_with("service", ["miner", "stop"], {"wallet_uuid": "the-source"})
         mock.wrapper.session.delete.assert_called_with(test_wallet)
         mock.wrapper.session.commit.assert_called_with()
 
@@ -277,6 +279,7 @@ class TestWallet(TestCase):
 
     def test__user_endpoint__delete__successful(self):
         test_wallet = mock.MagicMock()
+        test_wallet.source_uuid = "source"
 
         self.query_wallet.filter_by().first.return_value = test_wallet
 
@@ -286,6 +289,7 @@ class TestWallet(TestCase):
         self.assertEqual(expected_result, actual_result)
         self.query_wallet.filter_by.assert_called_with(source_uuid="source", key="the-key")
         self.query_wallet.filter_by().first.assert_called_with()
+        mock.m.contact_microservice.assert_called_with("service", ["miner", "stop"], {"wallet_uuid": "source"})
         mock.wrapper.session.delete.assert_called_with(test_wallet)
         mock.wrapper.session.commit.assert_called_with()
 


### PR DESCRIPTION
contact microservice service to stop all miner associated to a wallet which is going do be reseted or deleted to stop these miners

## Related Issue
#35 

## Motivation and Context
before the miner service kept running if theassociated wallet was removed

## How Has This Been Tested?
not yet tested


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
