### PR TITLE
Transactions in Pages

### DIFF
--- a/app/models/transaction.py
+++ b/app/models/transaction.py
@@ -1,7 +1,8 @@
 import datetime
 from typing import Union, List
 
-from sqlalchemy import Column, Integer, String, DateTime, or_
+from sqlalchemy import Column, Integer, String, DateTime, or_, desc
+from sqlalchemy.orm import Query
 
 from app import wrapper
 
@@ -51,10 +52,20 @@ class Transaction(wrapper.Base):
         return transaction
 
     @staticmethod
-    def get(source_uuid: str) -> List[dict]:
+    def query(source_uuid: str) -> Query:
+        return wrapper.session.query(Transaction).filter(
+            or_(Transaction.source_uuid == source_uuid, Transaction.destination_uuid == source_uuid)
+        )
+
+    @staticmethod
+    def count_transactions(source_uuid: str) -> int:
+        return Transaction.query(source_uuid).count()
+
+    @staticmethod
+    def slice_transactions(source_uuid: str, offset: int, count: int) -> List[dict]:
         return [
             transaction.serialize
-            for transaction in wrapper.session.query(Transaction).filter(
-                or_(Transaction.source_uuid == source_uuid, Transaction.destination_uuid == source_uuid)
-            )
+            for transaction in Transaction.query(source_uuid)
+            .order_by(desc(Transaction.time_stamp))
+            .slice(offset, offset + count)
         ]

--- a/app/resources/wallet.py
+++ b/app/resources/wallet.py
@@ -32,7 +32,13 @@ def create(data: dict, user: str) -> dict:
 def get(data: dict, user: str, wallet: Wallet) -> dict:
     update_miner(wallet)
 
-    return {**wallet.serialize, "transactions": Transaction.get(wallet.source_uuid)}
+    return {**wallet.serialize, "transactions": Transaction.count_transactions(wallet.source_uuid)}
+
+
+@m.user_endpoint(path=["transactions"], requires=scheme_transactions)
+@register_errors(wallet_exists, can_access_wallet)
+def transactions(data: dict, user: str, wallet: Wallet) -> dict:
+    return {"transactions": Transaction.slice_transactions(wallet.source_uuid, data["offset"], data["count"])}
 
 
 @m.user_endpoint(path=["list"], requires={})

--- a/app/schemes.py
+++ b/app/schemes.py
@@ -4,6 +4,8 @@ scheme_default: dict = {"source_uuid": UUID(), "key": Text(pattern=r"^[a-f0-9]{1
 
 scheme_reset: dict = {"source_uuid": UUID()}
 
+scheme_transactions: dict = {**scheme_default, "offset": Integer(minimum=0), "count": Integer(minimum=1)}
+
 scheme_send: dict = {
     "source_uuid": UUID(),
     "key": Text(pattern=r"^[a-f0-9]{10}$"),

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from mock.mock_loader import mock
 from resources import wallet
 from resources.errors import wallet_exists, can_access_wallet
-from schemes import scheme_default, scheme_send, scheme_reset
+from schemes import scheme_default, scheme_send, scheme_reset, scheme_transactions
 
 
 def import_app(name: str = "app"):
@@ -54,6 +54,7 @@ class TestApp(TestCase):
         expected_user_endpoints = [
             (["create"], {}, wallet.create),
             (["get"], scheme_default, wallet.get, wallet_exists, can_access_wallet),
+            (["transactions"], scheme_transactions, wallet.transactions, wallet_exists, can_access_wallet),
             (["list"], {}, wallet.list_wallets),
             (["send"], scheme_send, wallet.send, wallet_exists, can_access_wallet),
             (["reset"], scheme_reset, wallet.reset, wallet_exists),

--- a/app/tests/test_wallet.py
+++ b/app/tests/test_wallet.py
@@ -61,12 +61,22 @@ class TestWallet(TestCase):
     def test__user_endpoint__get__successful(self, transaction_patch, update_miner_patch):
         test_wallet = mock.MagicMock()
 
-        expected_result = {**test_wallet.serialize, "transactions": transaction_patch.get()}
+        expected_result = {**test_wallet.serialize, "transactions": transaction_patch.count_transactions()}
         actual_result = wallet.get({}, "", test_wallet)
 
         self.assertEqual(expected_result, actual_result)
         update_miner_patch.assert_called_with(test_wallet)
-        transaction_patch.get.assert_called_with(test_wallet.source_uuid)
+        transaction_patch.count_transactions.assert_called_with(test_wallet.source_uuid)
+
+    @patch("resources.wallet.Transaction")
+    def test__user_endpoint__transactions__successful(self, transaction_patch):
+        test_wallet = mock.MagicMock()
+
+        expected_result = {"transactions": transaction_patch.slice_transactions()}
+        actual_result = wallet.transactions({"count": 42, "offset": 1337}, "", test_wallet)
+
+        self.assertEqual(expected_result, actual_result)
+        transaction_patch.slice_transactions.assert_called_with(test_wallet.source_uuid, 1337, 42)
 
     def test__user_endpoint__list(self):
         wallets = [mock.MagicMock() for _ in range(5)]


### PR DESCRIPTION
## Description
Updated `/get` endpoint to return the number of transactions associated with the wallet and added a `/transactions` endpoint to fetch the next `count` transactions starting at `offset`.

## Related Issue
#50 

## How Has This Been Tested?
unit tests and tested with docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
